### PR TITLE
battery voltage sensor: make ADC attenuation configurable

### DIFF
--- a/settings.example-bob.py
+++ b/settings.example-bob.py
@@ -216,6 +216,8 @@ sensors = {
             # Resistor between input pin and ground (R2).
             'resistor_r2': 1000,
 
+            # ADC attenuation. possbible values: 0.0, 2.5, 6.0 or 11.0
+            'adc_attenuation_db': 6.0,
         },
 
     ],

--- a/settings.example.py
+++ b/settings.example.py
@@ -265,8 +265,8 @@ sensors = {
             # Resistor between input pin and ground (R2).
             'resistor_r2': 1000,
 
-            # ADC attenuation. possbible values: 0., 2.5, 6. or 11.
-            'adc_attenuation_db': 6.,
+            # ADC attenuation. possbible values: 0.0, 2.5, 6.0 or 11.0
+            'adc_attenuation_db': 6.0,
         },
 
     ],

--- a/settings.example.py
+++ b/settings.example.py
@@ -265,6 +265,8 @@ sensors = {
             # Resistor between input pin and ground (R2).
             'resistor_r2': 1000,
 
+            # ADC attenuation. possbible values: 0., 2.5, 6. or 11.
+            'adc_attenuation_db': 6.,
         },
 
     ],

--- a/terkin/sensor/system.py
+++ b/terkin/sensor/system.py
@@ -145,13 +145,13 @@ class SystemBatteryLevel(AbstractSystemSensor):
         # ADC channel used for sampling the raw value.
         from machine import ADC
 
-        if self.adc_attenuation_db == 0.:
+        if self.adc_attenuation_db == 0.0:
             self.adc_atten = ADC.ATTN_0DB
         elif self.adc_attenuation_db == 2.5:
             self.adc_atten = ADC.ATTN_2_5DB
-        elif self.adc_attenuation_db == 6.:
+        elif self.adc_attenuation_db == 6.0:
             self.adc_atten = ADC.ATTN_6DB
-        elif self.adc_attenuation_db == 11.:
+        elif self.adc_attenuation_db == 11.0:
             self.adc_atten = ADC.ATTN_11DB
         else:
             raise ValueError('ADC attenuation value (adc_attenuation_db) not allowed : {}'.format(self.adc_attenuation_db))

--- a/terkin/sensor/system.py
+++ b/terkin/sensor/system.py
@@ -135,7 +135,7 @@ class SystemBatteryLevel(AbstractSystemSensor):
         self.pin = self.settings.get('pin')
         self.resistor_r1 = self.settings.get('resistor_r1')
         self.resistor_r2 = self.settings.get('resistor_r2')
-        self.adc_attenuation_db = self.settings.get('adc_attenuation_db')
+        self.adc_attenuation_db = self.settings.get('adc_attenuation_db', 6.0)
 
         assert type(self.pin) is str, 'VCC Error: Voltage divider ADC pin invalid'
         assert type(self.resistor_r1) is int, 'VCC Error: Voltage divider resistor value "resistor_r1" invalid'
@@ -153,6 +153,8 @@ class SystemBatteryLevel(AbstractSystemSensor):
             self.adc_atten = ADC.ATTN_6DB
         elif self.adc_attenuation_db == 11.:
             self.adc_atten = ADC.ATTN_11DB
+        else:
+            raise ValueError('ADC attenuation value (adc_attenuation_db) not allowed : {}'.format(self.adc_attenuation_db))
 
         if platform_info.vendor == platform_info.MICROPYTHON.Vanilla:
             from machine import Pin

--- a/terkin/sensor/system.py
+++ b/terkin/sensor/system.py
@@ -135,13 +135,25 @@ class SystemBatteryLevel(AbstractSystemSensor):
         self.pin = self.settings.get('pin')
         self.resistor_r1 = self.settings.get('resistor_r1')
         self.resistor_r2 = self.settings.get('resistor_r2')
+        self.adc_attenuation_db = self.settings.get('adc_attenuation_db')
 
         assert type(self.pin) is str, 'VCC Error: Voltage divider ADC pin invalid'
         assert type(self.resistor_r1) is int, 'VCC Error: Voltage divider resistor value "resistor_r1" invalid'
         assert type(self.resistor_r2) is int, 'VCC Error: Voltage divider resistor value "resistor_r2" invalid'
+        assert type(self.adc_attenuation_db) is float, 'VCC Error: ADC attenuation value "adc_attenuation_db" invalid'
 
         # ADC channel used for sampling the raw value.
         from machine import ADC
+
+        if self.adc_attenuation_db == 0.:
+            self.adc_atten = ADC.ATTN_0DB
+        elif self.adc_attenuation_db == 2.5:
+            self.adc_atten = ADC.ATTN_2_5DB
+        elif self.adc_attenuation_db == 6.:
+            self.adc_atten = ADC.ATTN_6DB
+        elif self.adc_attenuation_db == 11.:
+            self.adc_atten = ADC.ATTN_11DB
+
         if platform_info.vendor == platform_info.MICROPYTHON.Vanilla:
             from machine import Pin
             self.adc = ADC(Pin(int(self.pin[1:])))
@@ -166,7 +178,7 @@ class SystemBatteryLevel(AbstractSystemSensor):
 
         # read samples
         if platform_info.vendor == platform_info.MICROPYTHON.Vanilla:
-            self.adc.atten(ADC.ATTN_6DB)
+            self.adc.atten(self.adc_atten)
             irq_state = disable_irq()
             while i < self.adc_sample_count:
                 adc_samples[i] = self.adc.read()
@@ -176,7 +188,7 @@ class SystemBatteryLevel(AbstractSystemSensor):
 
         elif platform_info.vendor == platform_info.MICROPYTHON.Pycom:
             self.adc.init()
-            adc_channel = self.adc.channel(attn=ADC.ATTN_6DB, pin=self.pin)
+            adc_channel = self.adc.channel(attn=self.adc_atten, pin=self.pin)
             irq_state = disable_irq()
             while i < self.adc_sample_count:
                 sample = adc_channel()


### PR DESCRIPTION
At least on my system (LoPy4 + Expansion Board 3.0) the hard coded 6db attenuation wasn't enough to not feed the ADC below it's maximum allowed voltage. By using 11db it works fine. Change preserves the attenuation default of 6db.