### PR TITLE
Power-down fixes for vanilla ESP32

### DIFF
--- a/terkin/lib/hx711.py
+++ b/terkin/lib/hx711.py
@@ -235,7 +235,8 @@ class HX711:
 
         # Hold level to HIGH, even during deep sleep.
         # https://community.hiveeyes.org/t/strom-sparen-beim-einsatz-der-micropython-firmware-im-batteriebetrieb/2055/72
-        self.pSCK.hold(True)
+        if platform_info.vendor == platform_info.MICROPYTHON.Pycom:
+            self.pSCK.hold(True)
 
 
 class DeviceNotFound(Exception):

--- a/terkin/sensor/core.py
+++ b/terkin/sensor/core.py
@@ -386,8 +386,9 @@ class I2CBus(AbstractBus):
             self.just_started = False
             return
 
-        # TODO: Add implementation for Vanilla MicroPython.
-        self.adapter.init(mode=I2C.MASTER, baudrate=self.frequency)
+        # uPy doesn't have deinit so it doesn't need init
+        if platform_info.vendor == platform_info.MICROPYTHON.Pycom:
+            self.adapter.init(mode=I2C.MASTER, baudrate=self.frequency)
 
     def power_off(self):
         """
@@ -396,7 +397,8 @@ class I2CBus(AbstractBus):
         https://docs.pycom.io/firmwareapi/pycom/machine/i2c.html
         """
         log.info('Turning off I2C bus {}'.format(self.name))
-        self.adapter.deinit()
+        if platform_info.vendor == platform_info.MICROPYTHON.Pycom:
+            self.adapter.deinit()
 
 
 def serialize_som(thing, stringify=None):


### PR DESCRIPTION
fixes for HX711 & I2C for powering down on the esp32