### PR TITLE
Downgrading pip to v19.3.1

### DIFF
--- a/tools/micropython.mk
+++ b/tools/micropython.mk
@@ -102,6 +102,9 @@ mpy-cross: check-mpy-version check-mpy-target
 
 mpy-cross-setup: setup-virtualenv2
 
+	@echo "$(INFO) Downgrading pip to 19.3.1"
+ @$(pip2) --quiet install pip==19.3.1
+
 	@mkdir -p bin/mpy-cross
 
 	@echo "$(INFO) Installing mpy-cross for MicroPython 1.9.4"

--- a/tools/micropython.mk
+++ b/tools/micropython.mk
@@ -103,7 +103,7 @@ mpy-cross: check-mpy-version check-mpy-target
 mpy-cross-setup: setup-virtualenv2
 
 	@echo "$(INFO) Downgrading pip to 19.3.1"
- @$(pip2) --quiet install pip==19.3.1
+	@$(pip2) --quiet install pip==19.3.1
 
 	@mkdir -p bin/mpy-cross
 


### PR DESCRIPTION
pip==20.0.1 breaks mpy-cross installation