### PR TITLE
Update presets-example.mk

### DIFF
--- a/presets-example.mk
+++ b/presets-example.mk
@@ -8,6 +8,9 @@
 # The serial port the device is attached to.
 MCU_PORT ?= /dev/ttyS3
 
+# Use "FiPy", "WiPy" or "LoPy" here for the appropriate PyCom device you are using.
+MCU_DEVICE ?= FiPy
+
 # Whether to cross-compile to bytecode.
 MPY_CROSS ?= true
 


### PR DESCRIPTION
In case you update the PyCom firmware via the sandbox tool and `make install-pycom-firmware` you have to specify `MCU_DEVICE`

> [ADVICE]  Please adjust the "MCU_DEVICE" environment variable like
>              export MCU_DEVICE=FiPy

Is there a reason why `MCU_DEVICE` is currently not in the `presets-example.mk`? E.g. conflicts in case there is a non-PyCom device connected or other circumstances? 

If this is not the case please consider to merge this pull request. ;-) 