### PR TITLE
support for HX711 channel B

### DIFF
--- a/src/lib/terkin/datalogger.py
+++ b/src/lib/terkin/datalogger.py
@@ -676,7 +676,7 @@ class TerkinDatalogger:
         interval = self.settings.get('main.interval.shutoff', 10) * 60  # convert from minutes to seconds
         (year,month,day,dotw,hour,minute,second) = ds.getDateTime() # get the current time
 
-        print('Time is: ', day,hour,minute)
+        #print('Time is: ', day,hour,minute)
 
         rtc = RTC() # create RTC
         if year < 2001:
@@ -690,17 +690,17 @@ class TerkinDatalogger:
         if (wake_at - now_secs) < 180:  # don't shutoff for less than 3 minutes
             wake_at += interval
 
-        print('Now:',now_secs, 'Wake at:', wake_at)
+        #print('Now:',now_secs, 'Wake at:', wake_at)
 
         (year,month,day,hour,minute,second, dotw, doty) = utime.localtime(wake_at) # convert the wake up time
 
         # set alarm
         ds.setAlarm2(day,hour,minute, DS3231tokei.A2_ON_HOUR_MINUTE)
 
-        print('Wake at: ', day,hour,minute)
+        #print('Wake at: ', day,hour,minute)
 
         # turn off MCU via MOSFET
-        print('Good night')
+        #print('Good night')
 
         utime.sleep(1)
 

--- a/src/lib/terkin/driver/hx711_sensor.py
+++ b/src/lib/terkin/driver/hx711_sensor.py
@@ -96,7 +96,7 @@ class HX711Sensor(AbstractSensor):
         log.info('Initializing HX711 sensor with '
                  'pin_dout={}, pin_pdsck={}, gain={}, scale={}, offset={}'.format(pin_dout, pin_pdsck, gain, scale, offset))
         if self.parameter['dualchannel']:
-            log.info('HX711 channel B with gain=32 '
+            log.info('Initializing HX711 sensor channel B with gain=32 '
                     'scale={}, offset={}'.format(scaleB, offsetB))
 
         try:

--- a/src/lib/terkin/lib/hx711.py
+++ b/src/lib/terkin/lib/hx711.py
@@ -121,10 +121,10 @@ class HX711:
         # Shift in data, gain & channel info.
         result = 0
         for j in range(24 + self.GAIN):
-            #state = disable_irq()
+            state = disable_irq()
             self.pSCK(True)
             self.pSCK(False)
-            #enable_irq(state)
+            enable_irq(state)
             result = (result << 1) | self.pOUT()
 
         # Shift back the extra bits.

--- a/src/lib/terkin/lib/hx711.py
+++ b/src/lib/terkin/lib/hx711.py
@@ -121,11 +121,11 @@ class HX711:
         # Shift in data, gain & channel info.
         result = 0
         for j in range(24 + self.GAIN):
-            state = disable_irq()
+            #state = disable_irq()
             self.pSCK(True)
             self.pSCK(False)
+            #enable_irq(state)
             result = (result << 1) | self.pOUT()
-            enable_irq(state)
 
         # Shift back the extra bits.
         result >>= self.GAIN

--- a/src/settings.example.py
+++ b/src/settings.example.py
@@ -422,8 +422,8 @@ sensors = {
             'pin_pdsck': 'P21',
             'offset': -73000,   # channel A
             'scale': 4.424242,  # channel A
-            'scaleB': 10767,    # channel B
             'offsetB': 11642,   # channel B            
+            'scaleB': 10767,    # channel B
             'decimals': 3,
         },
         {

--- a/src/settings.example.py
+++ b/src/settings.example.py
@@ -417,10 +417,13 @@ sensors = {
             'description': 'Waage 1',
             'type': 'HX711',
             'enabled': False,
+            'dualchannel': False,    # this will activate reading channel B
             'pin_dout': 'P22',
             'pin_pdsck': 'P21',
-            'offset': -73000,
-            'scale': 4.424242,
+            'offset': -73000,   # channel A
+            'scale': 4.424242,  # channel A
+            'scaleB': 10767,    # channel B
+            'offsetB': 11642,   # channel B            
             'decimals': 3,
         },
         {


### PR DESCRIPTION
first untested shot at supporting channel B on HX711

I'm not sure what to do here:
   ```
     # Propagate _all_ values from HX711 (raw, scale, offset, whatever).
        data = reading.get_data()
        for key, value in data.items():
            effective_key = 'scale.{}.{}'.format(address, key)
            effective_data[effective_key] = value
        return effective_data
```
I would like to propagate both readings plus the sum but this isn't supported by the current data format.