### PR TITLE
Enable NTP/RTC sync from settings with 'networking.ntp.enabled'

### DIFF
--- a/src/lib/terkin/device.py
+++ b/src/lib/terkin/device.py
@@ -141,8 +141,7 @@ class TerkinDevice:
             try:
                 self.start_rtc()
             except Exception as ex:
-                log.exc(ex, 'Unable start / sync RTC & NTP')
-
+                log.exc(ex, 'Unable to start/synchronize RTC with NTP')
 
         # Inform about networking status.
         #self.networking.print_status()
@@ -158,6 +157,7 @@ class TerkinDevice:
         from machine import RTC
         self.rtc = RTC()
         server = self.settings.get('networking.ntp.server')
+        log.info('Syncing RTC with NTP server "%s"', server)
         self.rtc.ntp_sync(server, 360)
         while not self.rtc.synced():
             time.sleep_ms(50)

--- a/src/lib/terkin/device.py
+++ b/src/lib/terkin/device.py
@@ -135,6 +135,15 @@ class TerkinDevice:
         else:
             log.info("[GPRS] Interface not enabled in settings.")
 
+        # Optionally sync time with NTP
+        ntp_enabled = self.settings.get('networking.ntp.enabled')
+        if self.status.networking and ntp_enabled:
+            try:
+                self.start_rtc()
+            except Exception as ex:
+                log.exc(ex, 'Unable start / sync RTC & NTP')
+
+
         # Inform about networking status.
         #self.networking.print_status()
 
@@ -148,8 +157,8 @@ class TerkinDevice:
         import time
         from machine import RTC
         self.rtc = RTC()
-        # TODO: Use values from configuration settings here.
-        self.rtc.ntp_sync("pool.ntp.org", 360)
+        server = self.settings.get('networking.ntp.server')
+        self.rtc.ntp_sync(server, 360)
         while not self.rtc.synced():
             time.sleep_ms(50)
         log.info('RTC: %s', self.rtc.now())

--- a/src/settings.example.py
+++ b/src/settings.example.py
@@ -95,6 +95,12 @@ interfaces = {
 
 # Networking configuration.
 networking = {
+    'ntp': {
+        # Must have networking enabled. Unsure if functional over LoRaWAN/TTN
+        'enabled': True,
+        'server': 'pool.ntp.org'
+    },
+
     'wifi': {
 
         # Enable/disable WiFi completely.

--- a/test/settings/rtc_ntp.py
+++ b/test/settings/rtc_ntp.py
@@ -1,0 +1,42 @@
+"""Datalogger configuration"""
+
+# General settings.
+main = {
+
+    # Measurement intervals in seconds.
+    'interval': {
+
+        # Apply this interval if device is in field mode.
+        'field': 0.0,
+
+    },
+
+    # Configure logging.
+    'logging': {
+
+        # Enable or disable logging completely.
+        'enabled': True,
+
+        # Log configuration settings at system startup.
+        'configuration': False,
+
+    },
+
+}
+
+# Networking configuration.
+networking = {
+    'ntp': {
+        # Must have networking enabled. Unsure if functional over LoRaWAN/TTN
+        'enabled': True,
+        'server': 'pool.example.org'
+    },
+    'wifi': {
+        # Enable/disable WiFi completely.
+        'enabled': True,
+        # WiFi stations to connect to in STA mode.
+        'stations': [
+            {'ssid': 'FooBarWiFi', 'password': 'secret', 'timeout': 15.0},
+        ],
+    },
+}

--- a/test/test_rtc_ntp.py
+++ b/test/test_rtc_ntp.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# (c) 2021 Andreas Motl <andreas@hiveeyes.org>
+# License: GNU General Public License, Version 3
+import mock
+import pytest
+import logging
+
+from pyfakefs.fake_filesystem_unittest import Patcher as FakeFS
+
+from test.util.terkin import invoke_umal
+
+
+@pytest.mark.basic
+@pytest.mark.esp32
+@mock.patch('sys.platform', 'esp32')
+def test_rtc_ntp_success(caplog):
+
+    # Use very basic settings without networking.
+    import test.settings.rtc_ntp as settings
+
+    with FakeFS():
+
+        with caplog.at_level(logging.DEBUG):
+
+            # Invoke bootloader.
+            bootloader = invoke_umal()
+
+            # Start datalogger with a single duty cycle on a fake filesystem.
+            from terkin.datalogger import TerkinDatalogger
+            datalogger = TerkinDatalogger(settings, platform_info=bootloader.platform_info)
+            datalogger.setup()
+            datalogger.duty_task()
+
+            # Capture log output.
+            captured = caplog.text
+
+            # Proof it works by verifying log output.
+            assert "Starting Terkin datalogger" in captured, captured
+            assert "platform: esp32" in captured, captured
+
+            assert "WiFi STA: Preparing connection to network \"FooBarWiFi\"" in captured, captured
+            assert "WiFi STA: Connected to \"FooBarWiFi\"" in captured, captured
+            assert "Network stack ready" in captured, captured
+
+            assert "Syncing RTC with NTP server \"pool.example.org\"" in captured, captured
+
+            assert "Reading 0 sensor ports" in captured, captured
+            assert "Sensor data:  {}" in captured, captured
+            assert "Telemetry status: SUCCESS (0/0)" in captured, captured
+
+    datalogger.device.rtc.ntp_sync.assert_called_once_with("pool.example.org", 360)
+    datalogger.device.rtc.now.assert_called()

--- a/test/util/micropython.py
+++ b/test/util/micropython.py
@@ -222,6 +222,9 @@ def monkeypatch_machine():
     # UART peripheral
     machine.UART = MagicMock()
 
+    # RTC module
+    machine.RTC = MagicMock()
+
 
 def wake_reason():
     from terkin.util import get_platform_info


### PR DESCRIPTION
This patch introduces two configuration settings `networking.ntp.enabled` and `networking.ntp.server` and handles them correspondingly. It is sensible to be used on MicroPython.