### PR TITLE
Adjust software tests to use Mosquitto 2.0

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 pytest==6.2.5
 pytest-pythonpath==0.7.3
-pytest-docker-fixtures==1.3.6
+pytest-docker-fixtures==1.3.12
 coverage==5.0.4
 
 pytest-mock==2.0.0

--- a/test/fixtures/mosquitto.py
+++ b/test/fixtures/mosquitto.py
@@ -9,27 +9,16 @@ from pytest_docker_fixtures.containers._base import BaseImage
 
 
 from pytest_docker_fixtures import images
-"""
-images.settings['mosquitto'] = {}
-images.configure(
-    'mosquitto',
-    'eclipse-mosquitto', '1.6.8',
-    env={},
-    options={
-        'ports': {
-            '1883': '1883'
-        }
-    })
-"""
 images.settings['mosquitto'] = {
     'image': 'eclipse-mosquitto',
-    'version': '1.6.8',
+    'version': '2.0.11',
     'options': {
+        'command': 'mosquitto -c /mosquitto-no-auth.conf',
         'publish_all_ports': False,
         'ports': {
             f'1883/tcp': '1883'
         }
-    }
+    },
 }
 
 


### PR DESCRIPTION
Hi there,

this patch accompanies https://community.hiveeyes.org/t/upgrade-to-mosquitto-2-0/4154.

With kind regards,
Andreas.
