### PR TITLE
Adjust software tests to use Mosquitto 2.0.12

### DIFF
--- a/test/fixtures/mosquitto.py
+++ b/test/fixtures/mosquitto.py
@@ -11,7 +11,7 @@ from pytest_docker_fixtures.containers._base import BaseImage
 from pytest_docker_fixtures import images
 images.settings['mosquitto'] = {
     'image': 'eclipse-mosquitto',
-    'version': '2.0.11',
+    'version': '2.0.12',
     'options': {
         'command': 'mosquitto -c /mosquitto-no-auth.conf',
         'publish_all_ports': False,


### PR DESCRIPTION
Hi there,

in order to investigate https://github.com/micropython/micropython-lib/issues/445, this bumps the Mosquitto version from 2.0.11 to 2.0.12. See also [1] ff.

With kind regards,
Andreas.

[1] https://community.hiveeyes.org/t/upgrade-to-mosquitto-2-0/4154