### PR TITLE
Use PyCryptodome instead of PyCrypto

### DIFF
--- a/requirements-sbc.txt
+++ b/requirements-sbc.txt
@@ -11,4 +11,4 @@ gpiozero==1.5.1
 rpi-piusv==0.1.0
 
 # Required for LoRaWAN.
-pycrypto==2.6.1
+pycryptodome==3.10.1

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ extras = {
     ],
     'lorawan': [
         # Required for LoRaWAN.
-        'pycrypto==2.6.1',
+        'pycryptodome==3.10.1',
     ],
 }
 


### PR DESCRIPTION
Hi,

this patch resolves #99, where the rationale for this update is outlined.

With kind regards,
Andreas.