### PR TITLE
Allow joining hidden WiFi on micropython devices (ignore Authmode detection error)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Terkin Datalogger CHANGES
 
 in progress
 ===========
+- Allow joining hidden WiFi APs on MicroPython devices. Thanks, @nznobody!
 
 
 2021-09-17 0.13.0

--- a/src/lib/terkin/network/wifi.py
+++ b/src/lib/terkin/network/wifi.py
@@ -319,8 +319,12 @@ class WiFiManager:
         auth_mode = None
         if self.platform_info.vendor == self.platform_info.MICROPYTHON.Pycom:
             log.info('WiFi STA: Getting auth mode')
-            auth_mode = self.get_auth_mode(network_name)
-            log.info('WiFi STA: Auth mode is "{}"'.format(auth_mode))
+            try:
+                auth_mode = self.get_auth_mode(network_name)
+                log.info('WiFi STA: Auth mode is "{}"'.format(auth_mode))
+            except WiFiException as _:
+                log.error('Failed to get auth mode, will attempt fresh')
+                auth_mode = None
 
         password = network['password']
 


### PR DESCRIPTION
make not detecting authmode an acceptable error to getting wifi going. Getting Auth mode fails on hidden networks as it does not show in the scan