### PR TITLE
Adjust/fix Dragino/LoRaWAN variant

### DIFF
--- a/requirements-sbc.txt
+++ b/requirements-sbc.txt
@@ -11,4 +11,4 @@ gpiozero==1.5.1
 rpi-piusv==0.1.0
 
 # Required for LoRaWAN.
-pycryptodome==3.10.1
+pycrypto==2.6.1

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ extras = {
     ],
     'lorawan': [
         # Required for LoRaWAN.
-        'pycryptodome==3.10.1',
+        'pycrypto==2.6.1',
     ],
 
     # Victron Energy VE.Direct text protocol driver.

--- a/tools/cpython.mk
+++ b/tools/cpython.mk
@@ -11,16 +11,6 @@ setup-cpython:
 	# Install CircuitPython libraries.
 	$(pip) install --requirement=requirements-cpython.txt --upgrade
 
-
-	@# Define path to the "dist-packages" installation directory.
-	$(eval target_dir := ./dist-packages)
-
-	# Install driver support for Dragino LoRa Hat.
-	curl --location https://github.com/daq-tools/dragino-lorawan/archive/ttn2-terkin.tar.gz | tar -C $(target_dir) --strip-components=1 -xzvf - dragino-lorawan-ttn2-terkin/dragino
-
-	# Install updated pySX127x driver.
-	curl --location https://github.com/daq-tools/pySX127x/archive/dragino.tar.gz | tar -C $(target_dir)/dragino --strip-components=1 -xzvf - pySX127x-dragino/SX127x
-
 ## Setup prerequisites for CPython on single-board-computers (SBC)
 setup-sbc:
 
@@ -62,9 +52,22 @@ run-cpython-callgraph:
 	dot -Tsvg pycallgraph.dot > pycallgraph.svg
 
 
-## Setup prerequisites for running on Raspberry Pi / Dragino
-setup-dragino:
+## Setup Dragino/LoRaWAN libraries
+setup-dragino-lorawan:
 	-$(MAKE) setup
 	-$(MAKE) setup-cpython
+
+	@# Define path to the "dist-packages" installation directory.
+	$(eval target_dir := ./dist-packages)
+
+	# Install driver support for Dragino LoRa Hat.
+	curl --location https://github.com/daq-tools/dragino-lorawan/archive/ttn2-terkin.tar.gz | tar -C $(target_dir) --strip-components=1 -xzvf - dragino-lorawan-ttn2-terkin/dragino
+
+	# Install updated pySX127x driver.
+	curl --location https://github.com/daq-tools/pySX127x/archive/dragino.tar.gz | tar -C $(target_dir)/dragino --strip-components=1 -xzvf - pySX127x-dragino/SX127x
+
+## Setup prerequisites for running on Raspberry Pi / Dragino
+setup-dragino:
+	-$(MAKE) setup-dragino-lorawan
 	-$(MAKE) setup-sbc
 	-$(MAKE) setup-gpsd

--- a/tools/cpython.mk
+++ b/tools/cpython.mk
@@ -16,7 +16,7 @@ setup-cpython:
 	$(eval target_dir := ./dist-packages)
 
 	# Install driver support for Dragino LoRa Hat.
-	curl --location https://github.com/daq-tools/dragino/archive/terkin.tar.gz | tar -C $(target_dir) --strip-components=1 -xzvf - dragino-terkin/dragino
+	curl --location https://github.com/daq-tools/dragino-lorawan/archive/ttn2-terkin.tar.gz | tar -C $(target_dir) --strip-components=1 -xzvf - dragino-lorawan-ttn2-terkin/dragino
 
 	# Install updated pySX127x driver.
 	curl --location https://github.com/daq-tools/pySX127x/archive/dragino.tar.gz | tar -C $(target_dir)/dragino --strip-components=1 -xzvf - pySX127x-dragino/SX127x


### PR DESCRIPTION
Hi there,

this patch has different adjustments for the Dragino/LoRaWAN variant.

- Resolve an incompatibility with PyCryptodome by downgrading to PyCrypto again (7c79dcd), reported at #108.
- The repository with the patched Dragino LoRaWAN implementation has been renamed to https://github.com/daq-tools/dragino-ttn2 in order to make room for the upcoming `dragino-ttn3` (332ee12).
- Make it easier to install the LoRaWAN stack without running on a real SBC (330a12b).

With kind regards,
Andreas.
