### PR TITLE
Add `timestamp` field into outbound telemetry message

### DIFF
--- a/src/lib/terkin/telemetry/core.py
+++ b/src/lib/terkin/telemetry/core.py
@@ -324,6 +324,14 @@ class TelemetryClient:
         # Resolve handler by URI.
         handler = self.get_handler(real_uri)
 
+        # Add timestamp to outbound telemetry message.
+        # TODO: Using the timestamp of the first reading is a bit vague.
+        #       How can it be improved?
+        try:
+            dataframe.data_out["timestamp"] = dataframe.readings[0].timestamp
+        except IndexError:
+            pass
+
         # Prepare dataframe for egress.
         dataframe.payload_out = dataframe.data_out
         if serialize:


### PR DESCRIPTION
Hi there,

this patch adds a `timestamp` field into the outbound telemetry message. Currently, we are using the timestamp of the first reading.

With kind regards,
Andreas.
